### PR TITLE
Don't check against URLs in requirements files

### DIFF
--- a/src/piplint/__init__.py
+++ b/src/piplint/__init__.py
@@ -61,6 +61,8 @@ def check_requirements(requirement_files, strict=False):
             return True
         if line.startswith('-'):
             return False
+        if line.startswith('http://') or line.startswith('https://'):
+            return False
         return True
 
 


### PR DESCRIPTION
When downloading a Python package from, say, a zipfile using http,
pip will report the proper version number, but the requirements
file will have a URL, which will cause a mismatch.

As an example, consider requirements.txt that contains:

https://github.com/dcramer/piplint/zipball/master

pip freeze will report:

piplint==0.1.1

Running piplint will cause an error:

$ piplint requirements.txt

Requirement 'https://github.com/dcramer/piplint/zipball/master' not found in virtualenv.
You must correct your environment before committing (and running tests).
